### PR TITLE
Run full E2E matrix only when PR approved

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our developer guide: https://submariner.io/development/
+2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
+3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
+4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
+5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
+6. Add labels to the PR as appropriate.
+
+This template is based on the K8s/K8s template:
+
+https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+-->

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,0 +1,42 @@
+---
+name: End to End Full
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  e2e:
+    name: E2E
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-test')
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deploytool: ['operator']
+        globalnet: ['', 'globalnet']
+        cable_driver: ['libreswan', 'wireguard']
+        ovn: ['', 'ovn']
+        k8s_version: ['1.20.2']
+        exclude:
+          - ovn: 'ovn'
+            globalnet: 'globalnet'
+          - ovn: 'ovn'
+            cable_driver: 'wireguard'
+        include:
+          # This is the oldest K8s version we try to support
+          - k8s_version: 1.17.17
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Run E2E deployment and tests
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
+          using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }} ${{ matrix.ovn }}
+
+      - name: Post mortem
+        if: failure()
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 ---
-name: End to End Tests
+name: End to End Default
 
 on:
   pull_request:
@@ -7,33 +7,14 @@ on:
 jobs:
   e2e:
     name: E2E
-    timeout-minutes: 45
+    timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        deploytool: ['operator']
-        globalnet: ['', 'globalnet']
-        cable_driver: ['libreswan', 'wireguard']
-        ovn: ['', 'ovn']
-        k8s_version: ['1.20.2']
-        exclude:
-          - ovn: 'ovn'
-            globalnet: 'globalnet'
-          - ovn: 'ovn'
-            cable_driver: 'wireguard'
-        include:
-          # This is the oldest K8s version we try to support
-          - k8s_version: 1.17.17
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
 
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
-        with:
-          k8s_version: ${{ matrix.k8s_version }}
-          using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }} ${{ matrix.ovn }}
 
       - name: Post mortem
         if: failure()

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Submariner
 
 <!-- markdownlint-disable line-length -->
-[![End to End Tests](https://github.com/submariner-io/submariner/workflows/End%20to%20End%20Tests/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3A%22End+to+End+Tests%22)
-[![Unit Tests](https://github.com/submariner-io/submariner/workflows/Unit%20Tests/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3A%22Unit+Tests%22)
-[![Linting](https://github.com/submariner-io/submariner/workflows/Linting/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3ALinting)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4865/badge)](https://bestpractices.coreinfrastructure.org/projects/4865)
 [![Release Images](https://github.com/submariner-io/submariner/workflows/Release%20Images/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3A%22Release+Images%22)
-[![Upgrade](https://github.com/submariner-io/submariner/workflows/Upgrade/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3AUpgrade)
 [![Periodic](https://github.com/submariner-io/submariner/workflows/Periodic/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3APeriodic)
 [![Flake Finder](https://github.com/submariner-io/submariner/workflows/Flake%20Finder/badge.svg)](https://github.com/submariner-io/submariner/actions?query=workflow%3A%22Flake+Finder%22)
 <!-- markdownlint-enable line-length -->

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -66,6 +66,50 @@ func (i *Controller) initIPTableChains() error {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForPods)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForPods); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForPods, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForHeadlessSvcPods)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForHeadlessSvcPods); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForHeadlessSvcPods, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForNamespace)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForNamespace); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForNamespace, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForCluster)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForCluster); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForCluster, err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForPods}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 2, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForHeadlessSvcPods}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 3, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForNamespace}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 4, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForCluster}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 5, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
 	return nil
 }
 

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -20,6 +20,12 @@ const (
 	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
 	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"
 
+	// The following chains are added as part of GN 2.0 implementation
+	SmGlobalnetEgressChainForPods            = "SM-GN-EGRESS-PODS"
+	SmGlobalnetEgressChainForHeadlessSvcPods = "SM-GN-EGRESS-HDLS-PODS"
+	SmGlobalnetEgressChainForNamespace       = "SM-GN-EGRESS-NS"
+	SmGlobalnetEgressChainForCluster         = "SM-GN-EGRESS-CLUSTER"
+
 	// IPTable chains used by RouteAgent
 	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
 


### PR DESCRIPTION
There's no need to run the full E2E test matrix before a PR is approved
for testing, so adding a default test for most of the time and changing
the matrix job to run only when the `ready-to-test` label is present.

The label will be applied once 2 approvals are given on the PR, but can
also be added (or removed) manually as needed.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>